### PR TITLE
Menghapus fungsi onActivityCreated()

### DIFF
--- a/fundamental/LatihanFragment/kotlin/app/src/main/java/com/dicoding/picodiploma/myflexiblefragment/DetailCategoryFragment.kt
+++ b/fundamental/LatihanFragment/kotlin/app/src/main/java/com/dicoding/picodiploma/myflexiblefragment/DetailCategoryFragment.kt
@@ -46,10 +46,6 @@ class DetailCategoryFragment : Fragment() {
             val mFragmentManager = childFragmentManager
             mOptionDialogFragment.show(mFragmentManager, OptionDialogFragment::class.java.simpleName)
         }
-    }
-
-    override fun onActivityCreated(savedInstanceState: Bundle?) {
-        super.onActivityCreated(savedInstanceState)
 
         if (savedInstanceState != null) {
             val descFromBundle = savedInstanceState.getString(EXTRA_DESCRIPTION)
@@ -80,5 +76,4 @@ class DetailCategoryFragment : Fragment() {
             Toast.makeText(activity, text, Toast.LENGTH_SHORT).show()
         }
     }
-
 }


### PR DESCRIPTION
Menghapus fungsi onActivityCreated() karena deprecated, tidak bermasalah terhadap program walaupun fungsi tsb dihapus dan fungsi tersebut bisa digantikan dengan onViewCreated() (yang mana sudah digunakan)